### PR TITLE
Simplify newline in log

### DIFF
--- a/logger.sh
+++ b/logger.sh
@@ -4,6 +4,6 @@ while true
 do
 	TIME=$(date +"%s")
 	curl -m 3 http://ice.portal2/jetty/api/v1/status >> $1
-	echo "\n" >> $1
+	echo >> $1
 	sleep 4.5s
 done


### PR DESCRIPTION
On my system echo does not interpret the \n char and it is printed to the file as is. This leads to other errors when converting later. Usually -e would be used, but that is also not available on every system from what I read.
echo without any param does the trick for me though.
