### PR TITLE
fail properly if no arguments are given

### DIFF
--- a/logger.sh
+++ b/logger.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ $# -ne 1 ]; then
+	echo "Usage: ${0} output.json" >&2
+	exit 1
+fi
+
 while true
 do
 	TIME=$(date +"%s")


### PR DESCRIPTION
Otherwise this cryptic error message will be shown:

` ./logger.sh: line 12: $1: ambiguous redirect`