### PR TITLE
use URL of the "new" ICE Portal (the one with wifi for the 2nd class)

### DIFF
--- a/logger.sh
+++ b/logger.sh
@@ -8,7 +8,7 @@ fi
 while true
 do
 	TIME=$(date +"%s")
-	curl -m 3 http://ice.portal/api1/rs/status >> $1
+	curl -m 3 https://portal.imice.de/api1/rs/status >> $1
 	echo >> $1
 	sleep 4.5s
 done


### PR DESCRIPTION
This pull request was sucessfully tested on ICE 374 with wifi for 2nd class and ICE Portal.

The API returns in car 1 of Tz 153 (BR 401):

```json
{"connection":true,"servicelevel":"AVAILABLE_SERVICE","speed":62,"longitude":8.480024333333333,"latitude":49.474265333333335,"serverTime":1494570070781,"wagonClass":1}
```